### PR TITLE
Fix (remove) rogue non-ascii character from socials.new. (#123)

### DIFF
--- a/lib/misc/socials.new
+++ b/lib/misc/socials.new
@@ -6109,7 +6109,7 @@ $n looks around for a victim to strangle.
 You throw yourself against $N's throat, trying to squeeze the life out.
 $n throws $mself after $N's throat.
 $n throws $mself after your throat, you try to defend yourself.
-AARGH! They must have left... #&%£@!
+AARGH! They must have left... #&%@!
 You put your hands around your throat and stop breathing.
 $n tries to strangle $mself, making a very strange noise and getting blue in the face.
 You strangle $M $t.


### PR DESCRIPTION
This character isn't ascii, nor even utf8.  It doesn't serve any real textual purpose either, so, just delete it.